### PR TITLE
add `toNext` array util

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.4.1
 
 - add `toNext` to `$lib/array`
-  ([#4](https://github.com/feltcoop/felt/pull/4))
+  ([#5](https://github.com/feltcoop/felt/pull/5))
 
 ## 0.4.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@
 
 ## 0.4.1
 
-- add `nexter` to `$lib/array`
-  ([#3](https://github.com/feltcoop/felt/pull/3))
+- add `toNext` to `$lib/array`
+  ([#4](https://github.com/feltcoop/felt/pull/4))
 
 ## 0.4.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,13 @@
 # changelog
 
+## 0.4.1
+
+- add `nexter` to `$lib/array`
+  ([#3](https://github.com/feltcoop/felt/pull/3))
+
 ## 0.4.0
 
-- **break**: rename `random-alea.ts` from `random-seeded.ts`
+- **break**: rename `$lib/random-alea` from `$lib/random-seeded`
   and `toRandomAlea` from `toRandomSeeded`
 
 ## 0.3.0
@@ -20,11 +25,11 @@
 
 - **break**: require fully qualified imports for almost everything
   ([#2](https://github.com/feltcoop/felt/pull/2))
-- **break**: change `getJsonType` in `json.ts` to return `undefined` instead of throwing
+- **break**: change `getJsonType` in `$lib/json` to return `undefined` instead of throwing
   ([#2](https://github.com/feltcoop/felt/pull/2))
 - **break**: rename camelCase filenames to dash-case,
-  `path-parsing.ts` from `pathParsing.ts` and
-  `random-seeded.ts` from `randomSeed.ts`
+  `$lib/path-parsing` from `$lib/pathParsing` and
+  `$lib/random-seeded` from `$lib/randomSeed`
   ([#2](https://github.com/feltcoop/felt/pull/2))
 
 ## 0.1.0

--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -13,7 +13,7 @@ export const removeUnordered = (array: any[], index: number): void => {
  * @param array
  * @returns A function that returns the next item in the `array`
  */
-export const nexter = <T>(array: T[]): (() => T) => {
+export const toNext = <T>(array: T[]): (() => T) => {
 	let i = -1;
 	return () => {
 		i++;

--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -6,3 +6,18 @@ export const removeUnordered = (array: any[], index: number): void => {
 	array[index] = array[array.length - 1];
 	array.pop();
 };
+
+/**
+ * Returns a function that returns the next item in the `array`
+ * in a linear sequence, looping back to index 0 when it reaches the end.
+ * @param array
+ * @returns A function that returns the next item in the `array`
+ */
+export const nexter = <T>(array: T[]): (() => T) => {
+	let i = -1;
+	return () => {
+		i++;
+		if (i >= array.length) i = 0;
+		return array[i];
+	};
+};


### PR DESCRIPTION
used here: https://github.com/feltcoop/felt-server/pull/627

the idea is that given an array, this creates a function that returns one item in a sequential loop, one at a time -- we'll probably add more API options eventually than just an incrementing loop, but this is a broadly useful utility for things like procedural generation (like seed files), similar to how `randomItem` is broadly useful -- this is basically just the predictable version of it.